### PR TITLE
fix: build, push mode, channel close, and cross-curve crash

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       mppx:
         specifier: '>=0.4.0'
-        version: 0.4.8(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(express@5.2.1)(hono@4.12.8)(openapi-types@12.1.3)(viem@2.47.6(zod@4.3.6))
+        version: 0.4.8(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(express@5.2.1)(hono@4.12.8)(openapi-types@12.1.3)(typescript@5.9.3)(viem@2.47.6(typescript@5.9.3)(zod@4.3.6))
       xrpl:
         specifier: '>=4.0.0'
         version: 4.6.0
@@ -645,7 +645,7 @@ packages:
     engines: {node: '>=16.0.0'}
 
   '@xrplf/secret-numbers@2.0.0':
-    resolution: {integrity: sha512-z3AOibRTE9E8MbjgzxqMpG1RNaBhQ1jnfhNCa1cGf2reZUJzPMYs4TggQTc7j8+0WyV3cr7y/U8Oz99SXIkN5Q==, tarball: https://artifactory.ops.ripple.com/artifactory/api/npm/ripple-npm/@xrplf/secret-numbers/-/@xrplf/secret-numbers-2.0.0.tgz}
+    resolution: {integrity: sha512-z3AOibRTE9E8MbjgzxqMpG1RNaBhQ1jnfhNCa1cGf2reZUJzPMYs4TggQTc7j8+0WyV3cr7y/U8Oz99SXIkN5Q==}
 
   abitype@1.2.3:
     resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
@@ -2029,8 +2029,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  abitype@1.2.3(zod@4.3.6):
+  abitype@1.2.3(typescript@5.9.3)(zod@4.3.6):
     optionalDependencies:
+      typescript: 5.9.3
       zod: 4.3.6
 
   accepts@2.0.0:
@@ -2447,13 +2448,13 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.3
 
-  mppx@0.4.8(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(express@5.2.1)(hono@4.12.8)(openapi-types@12.1.3)(viem@2.47.6(zod@4.3.6)):
+  mppx@0.4.8(@modelcontextprotocol/sdk@1.27.1(zod@4.3.6))(express@5.2.1)(hono@4.12.8)(openapi-types@12.1.3)(typescript@5.9.3)(viem@2.47.6(typescript@5.9.3)(zod@4.3.6)):
     dependencies:
       '@remix-run/fetch-proxy': 0.7.1
       '@remix-run/node-fetch-server': 0.13.0
       incur: 0.3.8(openapi-types@12.1.3)
-      ox: 0.14.8(zod@4.3.6)
-      viem: 2.47.6(zod@4.3.6)
+      ox: 0.14.8(typescript@5.9.3)(zod@4.3.6)
+      viem: 2.47.6(typescript@5.9.3)(zod@4.3.6)
       zod: 4.3.6
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.27.1(zod@4.3.6)
@@ -2493,7 +2494,7 @@ snapshots:
 
   openapi-types@12.1.3: {}
 
-  ox@0.14.7(zod@4.3.6):
+  ox@0.14.7(typescript@5.9.3)(zod@4.3.6):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -2501,12 +2502,14 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(zod@4.3.6)
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
       eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
     transitivePeerDependencies:
       - zod
 
-  ox@0.14.8(zod@4.3.6):
+  ox@0.14.8(typescript@5.9.3)(zod@4.3.6):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -2514,8 +2517,10 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(zod@4.3.6)
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
       eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
     transitivePeerDependencies:
       - zod
 
@@ -2837,16 +2842,18 @@ snapshots:
 
   vary@1.1.2: {}
 
-  viem@2.47.6(zod@4.3.6):
+  viem@2.47.6(typescript@5.9.3)(zod@4.3.6):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(zod@4.3.6)
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
       isows: 1.0.7(ws@8.18.3)
-      ox: 0.14.7(zod@4.3.6)
+      ox: 0.14.7(typescript@5.9.3)(zod@4.3.6)
       ws: 8.18.3
+    optionalDependencies:
+      typescript: 5.9.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate

--- a/sdk/src/channel/server/Channel.ts
+++ b/sdk/src/channel/server/Channel.ts
@@ -88,7 +88,13 @@ export function channel(parameters: channel.Parameters) {
     // This handles both ed25519 and secp256k1 keys transparently
     // verifyPaymentChannelClaim expects XRP (not drops) -- it internally calls xrpToDrops
     const claimXrp = dropsToXrp(payload.amount).toString()
-    const isValid = verifyPaymentChannelClaim(channelId, claimXrp, signature, publicKey)
+    let isValid: boolean
+    try {
+      isValid = verifyPaymentChannelClaim(channelId, claimXrp, signature, publicKey)
+    } catch {
+      // xrpl.js throws on malformed or cross-curve signatures instead of returning false
+      isValid = false
+    }
 
     if (!isValid) {
       throw invalidSignature('Claim signature verification failed')
@@ -161,7 +167,15 @@ export declare namespace channel {
 }
 
 /**
- * Close a PayChannel on-chain by submitting a PaymentChannelClaim with tfClose.
+ * Close a PayChannel on-chain.
+ *
+ * Behavior depends on who submits:
+ * - **Source (funder)**: submits PaymentChannelClaim with tfClose + claim details.
+ *   This initiates the settle delay, after which the channel can be deleted.
+ * - **Destination (recipient)**: submits PaymentChannelClaim to redeem funds
+ *   (without tfClose, since only the source can set tfClose on current XRPL).
+ *
+ * The function looks up the channel on-chain to detect the caller's role.
  */
 export async function close(params: {
   seed: string
@@ -189,7 +203,11 @@ export async function close(params: {
   await client.connect()
 
   try {
-    // tfClose = 0x00010000
+    // Look up the channel to determine the caller's role
+    const channelObj = await lookupChannel(client, channelId)
+    const isSource = channelObj?.Account === wallet.classicAddress
+
+    // tfClose = 0x00010000 -- only the source can use this flag
     const TF_CLOSE = 0x00010000
 
     const channelClaim = {
@@ -200,7 +218,7 @@ export async function close(params: {
       Amount: amount,
       Signature: signature.toUpperCase(),
       PublicKey: channelPublicKey,
-      Flags: TF_CLOSE,
+      ...(isSource ? { Flags: TF_CLOSE } : {}),
     }
 
     const result = await client.submitAndWait(channelClaim, { wallet })
@@ -213,5 +231,20 @@ export async function close(params: {
     return { txHash: result.result.hash }
   } finally {
     await client.disconnect()
+  }
+}
+
+/**
+ * Look up a PayChannel object on-chain by channel ID.
+ */
+async function lookupChannel(client: Client, channelId: string): Promise<any | null> {
+  try {
+    const response = await client.request({
+      command: 'ledger_entry',
+      index: channelId,
+    } as any)
+    return (response.result as any).node ?? null
+  } catch {
+    return null
   }
 }

--- a/sdk/src/server/Charge.ts
+++ b/sdk/src/server/Charge.ts
@@ -129,8 +129,10 @@ async function verifyPush(
     transaction: txHash,
   })
 
-  const tx = txResponse.result as any
-  const meta = tx.meta ?? tx.metaData
+  const result = txResponse.result as any
+  // xrpl.js v4: transaction fields are nested under tx_json
+  const tx = result.tx_json ?? result
+  const meta = result.meta ?? result.metaData ?? tx.meta ?? tx.metaData
 
   if (!meta || meta.TransactionResult !== 'tesSUCCESS') {
     const tecResult = meta?.TransactionResult ?? 'unknown'
@@ -247,6 +249,9 @@ async function verifyPull(
 
 /**
  * Validate that a Payment transaction's Destination and Amount match expectations.
+ *
+ * Handles both legacy format (Amount at top level) and xrpl.js v4 format
+ * (fields in tx_json, Amount renamed to DeliverMax).
  */
 function validatePaymentFields(tx: any, expectedAmount: string, expectedRecipient: string): void {
   // Validate destination
@@ -258,8 +263,8 @@ function validatePaymentFields(tx: any, expectedAmount: string, expectedRecipien
     )
   }
 
-  // Validate amount
-  const txAmount = tx.Amount
+  // Validate amount -- xrpl.js v4 renames Amount to DeliverMax in tx responses
+  const txAmount = tx.Amount ?? tx.DeliverMax
   if (typeof txAmount === 'string') {
     // XRP native -- amount is drops string
     if (txAmount !== expectedAmount) {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: {
+    index: 'sdk/src/index.ts',
+    'client/index': 'sdk/src/client/index.ts',
+    'server/index': 'sdk/src/server/index.ts',
+    'channel/index': 'sdk/src/channel/index.ts',
+    'channel/client/index': 'sdk/src/channel/client/index.ts',
+    'channel/server/index': 'sdk/src/channel/server/index.ts',
+  },
+  format: 'esm',
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  outDir: 'dist',
+  external: ['xrpl', 'mppx'],
+})


### PR DESCRIPTION
## Summary

Fixes 5 bugs found during comprehensive integration testing against XRPL testnet:

- **Build broken**: `pnpm build` failed with "No input files" — added `tsup.config.ts` with all 6 entry points matching `package.json` exports
- **Lockfile blocked install**: `pnpm-lock.yaml` referenced `artifactory.ops.ripple.com` (Ripple internal registry) for `@xrplf/secret-numbers` — regenerated from public npm
- **Push mode charge failed**: `verifyPush()` read tx fields from top-level result, but xrpl.js v4 nests them under `tx_json` and renames `Amount` → `DeliverMax`
- **Channel close `tecNO_PERMISSION`**: `close()` always set `tfClose`, but current XRPL restricts this flag to the channel source — now detects caller role via `ledger_entry` lookup
- **Cross-curve signature crash**: `verifyPaymentChannelClaim()` from xrpl.js throws on malformed/cross-curve signatures instead of returning `false` — wrapped in try/catch

## Changes

| File | Change |
|---|---|
| `tsup.config.ts` | New — 6 ESM entry points, external xrpl/mppx |
| `pnpm-lock.yaml` | Regenerated — removed private registry URL |
| `sdk/src/server/Charge.ts` | `verifyPush`: read from `tx_json`, handle `DeliverMax` |
| `sdk/src/channel/server/Channel.ts` | `close()`: detect source vs destination role; `doVerify`: try/catch on signature verification |

## Test plan

- [x] `pnpm check:types` — passes
- [x] `pnpm test` — 105/105 unit tests pass
- [x] `pnpm build` — builds all 6 entry points with types
- [x] Integration benchmark (120 tests against XRPL testnet):
  - XRP charge pull mode E2E (402 → payment → 200 + receipt)
  - XRP charge push mode E2E (client submits, server verifies hash)
  - PayChannel: open → 5 off-chain claims → fund → destination claim → source close
  - Dual-curve signing (ed25519 + secp256k1)
  - Cross-curve signature rejection (no crash)
  - Currency utilities, error mapping, edge cases